### PR TITLE
Add block-based method and localize alert view

### DIFF
--- a/Classes/HSLUpdateChecker.h
+++ b/Classes/HSLUpdateChecker.h
@@ -18,5 +18,6 @@
 @interface HSLUpdateChecker : NSObject <UIAlertViewDelegate>
 
 + (void) checkForUpdate;
++ (void) checkForUpdateWithHandler:(void (^)(NSString *appStoreVersion, NSString *localVersion, NSString *releaseNotes, NSString *updateURL))handler;
 
 @end


### PR DESCRIPTION
Refactored the code to use a block instead. This allows you to use a custom handler as well.

(Also localized the UIAlertView)
